### PR TITLE
Improve privacy page footer link

### DIFF
--- a/BlackridgePortfolio/index.html
+++ b/BlackridgePortfolio/index.html
@@ -261,6 +261,7 @@
                     <a href="#orbas" class="text-dark-gray hover:text-primary transition-colors font-medium">Orbas</a>
                     <a href="#vision" class="text-dark-gray hover:text-primary transition-colors font-medium">Vision</a>
                     <a href="#contact" class="text-dark-gray hover:text-primary transition-colors font-medium">Contact</a>
+                    <a href="privacy.html" class="text-dark-gray hover:text-primary transition-colors font-medium">Privacy</a>
                 </div>
                 
                 <!-- Mobile Menu Button -->
@@ -279,6 +280,7 @@
                     <a href="#orbas" class="text-dark-gray hover:text-primary transition-colors font-medium">Orbas</a>
                     <a href="#vision" class="text-dark-gray hover:text-primary transition-colors font-medium">Vision</a>
                     <a href="#contact" class="text-dark-gray hover:text-primary transition-colors font-medium">Contact</a>
+                    <a href="privacy.html" class="text-dark-gray hover:text-primary transition-colors font-medium">Privacy</a>
                 </div>
             </div>
         </nav>
@@ -668,7 +670,7 @@
                         <a href="#values" class="block text-slate-300 hover:text-white transition-colors">Our Values</a>
                         <a href="#vision" class="block text-slate-300 hover:text-white transition-colors">Vision & Mission</a>
                         <a href="https://orbas.io" target="_blank" rel="noopener noreferrer" class="block text-slate-300 hover:text-white transition-colors">Orbas Platform</a>
-                        <a href="#" class="block text-slate-300 hover:text-white transition-colors">Privacy Policy</a>
+                        <a href="privacy.html" class="block text-slate-300 hover:text-white transition-colors">Privacy Policy</a>
                         <a href="#" class="block text-slate-300 hover:text-white transition-colors">Terms of Service</a>
                     </nav>
                 </div>
@@ -701,7 +703,7 @@
                     © 2025 Blackridge Group Ltd. All rights reserved. | Company Registration: 16482166
                 </p>
                 <p class="text-slate-500 text-xs mt-2">
-                    This website uses cookies to enhance user experience. By continuing to browse, you agree to our Privacy Policy.
+                    This website uses cookies to enhance user experience. By continuing to browse, you agree to our <a href="privacy.html#cookies" class="underline hover:text-white">Privacy Policy</a>.
                 </p>
             </div>
         </div>

--- a/BlackridgePortfolio/privacy.html
+++ b/BlackridgePortfolio/privacy.html
@@ -1,0 +1,323 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy - Blackridge Group Ltd</title>
+    <meta name="description" content="Privacy policy for Blackridge Group Ltd explaining how we handle personal data in accordance with UK GDPR.">
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+
+    <!-- Google Fonts - Poppins -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <!-- AOS Animation Library -->
+    <link href="https://unpkg.com/aos@2.3.1/dist/aos.css" rel="stylesheet">
+    <script src="https://unpkg.com/aos@2.3.1/dist/aos.js"></script>
+
+    <!-- Custom Configuration -->
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'poppins': ['Poppins', 'sans-serif'],
+                    },
+                    colors: {
+                        'primary': '#0EA5E9',
+                        'primary-light': '#38BDF8',
+                        'primary-dark': '#0284C7',
+                        'secondary': '#64748B',
+                        'dark-gray': '#1F2937',
+                        'light-gray': '#6B7280',
+                        'border-gray': '#E5E7EB',
+                        'bg-light': '#F8FAFC'
+                    }
+                }
+            }
+        }
+    </script>
+
+    <style>
+        body {
+            font-family: 'Poppins', sans-serif;
+        }
+        .section-enterprise {
+            padding: 5rem 2rem;
+        }
+        .section-overlap {
+            margin-top: -4rem;
+            position: relative;
+            z-index: 10;
+        }
+        .parallax-hero {
+            transition: transform 0.1s ease-out;
+        }
+    </style>
+</head>
+<body class="bg-white text-dark-gray">
+
+    <!-- Sticky Header -->
+    <header class="fixed top-0 left-0 right-0 z-50 bg-white/90 backdrop-blur-md border-b border-border-gray">
+        <nav class="container mx-auto px-4 py-3 md:px-6 md:py-4 mobile-nav tablet-nav">
+            <div class="flex justify-between items-center">
+                <!-- Logo -->
+                <div class="flex items-center space-x-3">
+                    <img src="assets/blackridge-logo.png" alt="Blackridge Group Ltd" class="h-14 w-auto md:h-12 lg:h-14 mobile-logo tablet-logo">
+                </div>
+
+                <!-- Desktop Navigation -->
+                <div class="hidden md:flex space-x-8">
+                    <a href="index.html#about" class="text-dark-gray hover:text-primary transition-colors font-medium">About</a>
+                    <a href="index.html#values" class="text-dark-gray hover:text-primary transition-colors font-medium">Values</a>
+                    <a href="index.html#orbas" class="text-dark-gray hover:text-primary transition-colors font-medium">Orbas</a>
+                    <a href="index.html#vision" class="text-dark-gray hover:text-primary transition-colors font-medium">Vision</a>
+                    <a href="index.html#contact" class="text-dark-gray hover:text-primary transition-colors font-medium">Contact</a>
+                    <a href="privacy.html" class="text-dark-gray hover:text-primary transition-colors font-medium">Privacy</a>
+                </div>
+
+                <!-- Mobile Menu Button -->
+                <button id="mobile-menu-button" class="md:hidden text-dark-gray hover:text-primary">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+                    </svg>
+                </button>
+            </div>
+
+            <!-- Mobile Menu -->
+            <div id="mobile-menu" class="hidden md:hidden mt-4 pb-4 border-t border-border-gray">
+                <div class="flex flex-col space-y-3 pt-4">
+                    <a href="index.html#about" class="text-dark-gray hover:text-primary transition-colors font-medium">About</a>
+                    <a href="index.html#values" class="text-dark-gray hover:text-primary transition-colors font-medium">Values</a>
+                    <a href="index.html#orbas" class="text-dark-gray hover:text-primary transition-colors font-medium">Orbas</a>
+                    <a href="index.html#vision" class="text-dark-gray hover:text-primary transition-colors font-medium">Vision</a>
+                    <a href="index.html#contact" class="text-dark-gray hover:text-primary transition-colors font-medium">Contact</a>
+                    <a href="privacy.html" class="text-dark-gray hover:text-primary transition-colors font-medium">Privacy</a>
+                </div>
+            </div>
+        </nav>
+    </header>
+
+    <main class="section-enterprise bg-white pt-32 pb-16">
+        <div class="container mx-auto max-w-4xl" data-aos="fade-up">
+            <h1 class="text-3xl font-bold text-dark-gray mb-6">Privacy Policy</h1>
+            <p class="text-light-gray mb-4">This Privacy Policy explains how Blackridge Group Ltd ("Blackridge", "we", "us" or "our") collects, uses and protects your personal data when you visit our website or interact with us. We are committed to processing personal data fairly, transparently and in accordance with the UK General Data Protection Regulation (UK GDPR) and the Data Protection Act 2018.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">1. Data Controller</h2>
+            <p class="text-light-gray mb-4">Blackridge Group Ltd is the data controller for the personal data processed via this website. Our registered office is 61 Bridge Street, Kington, Hertfordshire, HR5 3DJ, United Kingdom. If you have any questions about this policy or your rights, please contact us at <a href="mailto:info@blackridgegroup.online" class="text-primary hover:underline">info@blackridgegroup.online</a>.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">2. What Information We Collect</h2>
+            <p class="text-light-gray mb-4">We may collect and process the following categories of personal data:</p>
+            <ul class="list-disc list-inside text-light-gray mb-4">
+                <li>Contact information such as your name, email address and phone number when you communicate with us.</li>
+                <li>Technical data including IP address, browser type, device identifiers and cookie data when you browse our site.</li>
+                <li>Any other information you choose to provide when interacting with us.</li>
+            </ul>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">3. How We Use Your Information</h2>
+            <p class="text-light-gray mb-4">We use personal data for the following purposes:</p>
+            <ul class="list-disc list-inside text-light-gray mb-4">
+                <li>To respond to your enquiries and provide customer support.</li>
+                <li>To operate, maintain and improve our website.</li>
+                <li>To comply with our legal obligations and protect our legal rights.</li>
+                <li>With your consent, to send you marketing communications about our services.</li>
+            </ul>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">4. Legal Bases for Processing</h2>
+            <p class="text-light-gray mb-4">We process personal data on the following legal bases:</p>
+            <ul class="list-disc list-inside text-light-gray mb-4">
+                <li><span class="font-medium">Consent</span> &ndash; where you have given clear consent to process your personal data for a specific purpose.</li>
+                <li><span class="font-medium">Contract</span> &ndash; where processing is necessary to perform a contract with you or to take steps at your request before entering into a contract.</li>
+                <li><span class="font-medium">Legal obligation</span> &ndash; where processing is necessary for compliance with a legal obligation.</li>
+                <li><span class="font-medium">Legitimate interests</span> &ndash; where processing is necessary for our legitimate interests and your interests and fundamental rights do not override those interests.</li>
+            </ul>
+
+            <h2 id="cookies" class="text-2xl font-semibold text-dark-gray mt-8 mb-4">5. Cookies and Tracking Technologies</h2>
+            <p class="text-light-gray mb-4">Our site uses cookies and similar technologies to understand how visitors interact with our pages and to improve functionality. Cookies may be stored on your device when you browse this site.</p>
+            <ul class="list-disc list-inside text-light-gray mb-4">
+                <li><span class="font-medium">Strictly necessary cookies</span> &ndash; required for core site features and security.</li>
+                <li><span class="font-medium">Analytics cookies</span> &ndash; help us analyse site usage so we can measure and improve performance.</li>
+                <li><span class="font-medium">Marketing cookies</span> &ndash; used only with your consent to deliver relevant content.</li>
+            </ul>
+            <p class="text-light-gray mb-4">You can control or delete cookies at any time through your browser settings. Disabling cookies may affect your browsing experience.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">6. Data Sharing</h2>
+            <p class="text-light-gray mb-4">We may disclose personal data to trusted third parties that assist us in running our business. These include:</p>
+            <ul class="list-disc list-inside text-light-gray mb-4">
+                <li>Service providers such as hosting, analytics and email delivery partners.</li>
+                <li>Professional advisers including lawyers, bankers, auditors and insurers.</li>
+                <li>Regulators and authorities where required by law.</li>
+            </ul>
+            <p class="text-light-gray mb-4">All third parties are required to respect the security of your data and treat it in accordance with the law. We never sell your personal data.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">7. Third-Party Links</h2>
+            <p class="text-light-gray mb-4">Our website may contain links to third-party sites. We are not responsible for the privacy practices of those sites and encourage you to read their privacy notices.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">8. International Transfers</h2>
+            <p class="text-light-gray mb-4">If we transfer personal data outside the UK, we ensure appropriate safeguards are in place, such as standard contractual clauses approved by the UK Information Commissioner&rsquo;s Office (ICO).</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">9. Data Retention</h2>
+            <p class="text-light-gray mb-4">We keep personal data only for as long as necessary to fulfil the purposes we collected it for, including to satisfy any legal, accounting or reporting requirements.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">10. Your Rights</h2>
+            <p class="text-light-gray mb-4">Under the UK GDPR, you have the right to:</p>
+            <ul class="list-disc list-inside text-light-gray mb-4">
+                <li>Request access to your personal data.</li>
+                <li>Request correction or erasure of your data.</li>
+                <li>Object to or restrict our processing of your data.</li>
+                <li>Request data portability.</li>
+                <li>Withdraw consent at any time where we rely on consent.</li>
+                <li>Lodge a complaint with the ICO if you believe we have not complied with data protection laws.</li>
+            </ul>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">11. Exercising Your Rights</h2>
+            <p class="text-light-gray mb-4">To make a data subject request, please contact us at <a href="mailto:info@blackridgegroup.online" class="text-primary hover:underline">info@blackridgegroup.online</a>. We may ask for proof of identity and will respond within one month.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">12. Security</h2>
+            <p class="text-light-gray mb-4">We implement appropriate technical and organisational measures to protect personal data against unauthorised access, alteration, disclosure or destruction.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">13. Children</h2>
+            <p class="text-light-gray mb-4">Our website is not directed at children under 13 and we do not knowingly collect personal data from children.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">14. Changes to This Policy</h2>
+            <p class="text-light-gray mb-4">We may update this Privacy Policy from time to time. The latest version will always be posted on this page with an updated revision date.</p>
+
+            <h2 class="text-2xl font-semibold text-dark-gray mt-8 mb-4">15. Contact Us</h2>
+            <p class="text-light-gray mb-4">If you have questions about this Privacy Policy or how we handle your personal data, please contact us at <a href="mailto:info@blackridgegroup.online" class="text-primary hover:underline">info@blackridgegroup.online</a>.</p>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer id="contact" class="section-enterprise bg-slate-900 text-white">
+        <div class="container mx-auto max-w-6xl">
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-12 mb-12">
+                <!-- Company Info -->
+                <div data-aos="fade-up">
+                    <img src="assets/blackridge-logo.png" alt="Blackridge Group Ltd" class="h-10 w-auto mb-6 filter brightness-0 invert">
+                    <p class="text-slate-300 leading-relaxed mb-6">
+                        Transforming digital infrastructure through ethical, scalable platforms that empower global communities.
+                    </p>
+                    <div class="space-y-2">
+                        <p class="text-sm text-slate-400">Registered Address:</p>
+                        <p class="text-slate-300">
+                            61 Bridge Street<br>
+                            Kington<br>
+                            Hertfordshire<br>
+                            HR5 3DJ<br>
+                            United Kingdom
+                        </p>
+                    </div>
+                </div>
+
+                <!-- Quick Links -->
+                <div data-aos="fade-up" data-aos-delay="200">
+                    <h3 class="text-xl font-bold mb-6">Quick Links</h3>
+                    <nav class="space-y-3">
+                        <a href="index.html#about" class="block text-slate-300 hover:text-white transition-colors">About Us</a>
+                        <a href="index.html#values" class="block text-slate-300 hover:text-white transition-colors">Our Values</a>
+                        <a href="index.html#vision" class="block text-slate-300 hover:text-white transition-colors">Vision &amp; Mission</a>
+                        <a href="https://orbas.io" target="_blank" rel="noopener noreferrer" class="block text-slate-300 hover:text-white transition-colors">Orbas Platform</a>
+                        <a href="privacy.html" class="block text-slate-300 hover:text-white transition-colors">Privacy Policy</a>
+                        <a href="#" class="block text-slate-300 hover:text-white transition-colors">Terms of Service</a>
+                    </nav>
+                </div>
+
+                <!-- Contact Info -->
+                <div data-aos="fade-up" data-aos-delay="400">
+                    <h3 class="text-xl font-bold mb-6">Get In Touch</h3>
+                    <div class="space-y-4">
+                        <div class="flex items-center space-x-3">
+                            <svg class="w-5 h-5 text-primary-light" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                            </svg>
+                            <a href="mailto:info@blackridgegroup.online" class="text-slate-300 hover:text-white transition-colors">
+                                info@blackridgegroup.online
+                            </a>
+                        </div>
+                        <div class="flex items-center space-x-3">
+                            <svg class="w-5 h-5 text-primary-light" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+                            </svg>
+                            <a href="https://www.linkedin.com/company/blackridge-group-ltd/" target="_blank" rel="noopener noreferrer" class="text-slate-300 hover:text-white transition-colors">LinkedIn</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Bottom Bar -->
+            <div class="border-t border-slate-700 pt-8 text-center" data-aos="fade-up" data-aos-delay="600">
+                <p class="text-slate-400 text-sm">
+                    © 2025 Blackridge Group Ltd. All rights reserved. | Company Registration: 16482166
+                </p>
+                <p class="text-slate-500 text-xs mt-2">
+                    This website uses cookies to enhance user experience. By continuing to browse, you agree to our <a href="#cookies" class="underline hover:text-white">Privacy Policy</a>.
+                </p>
+            </div>
+        </div>
+    </footer>
+
+    <!-- JavaScript -->
+    <script>
+        // Initialize AOS
+        AOS.init({
+            duration: 800,
+            easing: 'ease-in-out',
+            once: true,
+            offset: 100
+        });
+
+        // Mobile menu toggle
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+
+        mobileMenuButton.addEventListener('click', () => {
+            mobileMenu.classList.toggle('hidden');
+        });
+
+        // Close mobile menu when clicking on a link
+        const mobileLinks = mobileMenu.querySelectorAll('a');
+        mobileLinks.forEach(link => {
+            link.addEventListener('click', () => {
+                mobileMenu.classList.add('hidden');
+            });
+        });
+
+        // Smooth scroll for all anchor links
+        document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+            anchor.addEventListener('click', function (e) {
+                // allow internal page anchors only
+                if (this.getAttribute('href').startsWith('#')) {
+                    e.preventDefault();
+                    const target = document.querySelector(this.getAttribute('href'));
+                    if (target) {
+                        const headerOffset = 100;
+                        const elementPosition = target.offsetTop;
+                        const offsetPosition = elementPosition - headerOffset;
+                        window.scrollTo({
+                            top: offsetPosition,
+                            behavior: 'smooth'
+                        });
+                    }
+                }
+            });
+        });
+
+        // Header scroll effect
+        window.addEventListener('scroll', () => {
+            const header = document.querySelector('header');
+            if (window.scrollY > 50) {
+                header.classList.add('shadow-lg');
+                header.classList.remove('shadow-sm');
+            } else {
+                header.classList.add('shadow-sm');
+                header.classList.remove('shadow-lg');
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link the cookie notice on `privacy.html` directly to the cookies section
- confirmed privacy policy uses the registered address
- verified all privacy links route to the new page

## Testing
- `grep -R "privacy.html" -n | head`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880d0a6a7248320b0b739379bf6b705