### PR TITLE
Move logo to the right of the wordmark

### DIFF
--- a/BlackridgePortfolio/index.html
+++ b/BlackridgePortfolio/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blackwellen Ltd &mdash; Tech-Focused Investment Holdings Company</title>
     <meta name="description" content="Blackwellen Ltd is a technology-focused investment company building and backing high-potential brands, digital platforms, and emerging technologies.">
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="https://i.ibb.co/s912pw8N/craiyon-013816-image.png">
+    <link rel="shortcut icon" href="https://i.ibb.co/s912pw8N/craiyon-013816-image.png">
 
     <!-- Google Fonts - Poppins -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -371,15 +371,12 @@
     <header class="fixed top-0 left-0 right-0 z-50 bg-onyx/85 backdrop-blur-xl border-b border-divider">
         <nav class="container mx-auto max-w-7xl px-4 py-4">
             <div class="flex items-center justify-between">
-                <!-- Logo Placeholder -->
                 <div class="flex items-center space-x-3">
-                    <div class="h-11 w-11 rounded-full border border-gilded/60 bg-gradient-to-br from-gilded/20 via-gilded/5 to-transparent flex items-center justify-center">
-                        <span class="text-gilded text-xl font-semibold">B</span>
-                    </div>
                     <div>
                         <span class="block text-sm tracking-[0.4em] uppercase text-gilded">Blackwellen</span>
                         <span class="block text-lg font-semibold text-white">Ltd</span>
                     </div>
+                    <img src="https://i.ibb.co/tTyXFvBL/craiyon-013431-image.png" alt="Blackwellen Ltd logo" class="h-[7.5rem] w-auto object-contain">
                 </div>
 
                 <!-- Desktop Navigation -->
@@ -714,13 +711,11 @@
                 <!-- Company Info -->
                 <div data-aos="fade-up">
                     <div class="flex items-center space-x-3 mb-6">
-                        <div class="h-11 w-11 rounded-full border border-gilded/60 bg-gradient-to-br from-gilded/20 via-gilded/5 to-transparent flex items-center justify-center">
-                            <span class="text-gilded text-xl font-semibold">B</span>
-                        </div>
                         <div>
                             <span class="block text-sm tracking-[0.4em] uppercase text-gilded">Blackwellen</span>
                             <span class="block text-lg font-semibold text-white">Ltd</span>
                         </div>
+                        <img src="https://i.ibb.co/tTyXFvBL/craiyon-013431-image.png" alt="Blackwellen Ltd logo" class="h-[7.5rem] w-auto object-contain">
                     </div>
                     <p class="text-soft-gray leading-relaxed mb-6">
                         Blackwellen Ltd looks after three future-focused web portals that blend technology, creativity, and practical use.


### PR DESCRIPTION
## Summary
- swap the brand text and image order in the header so the logo sits to the right of the wordmark
- mirror the same right-aligned logo placement within the footer company block for consistency

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4627075808320a32178633f81f66a